### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - sudo miktexsetup --shared=yes finish
   - sudo initexmf --admin --set-config-value [MPM]AutoInstall=1
   - sudo mpm --admin --package-level=basic --find-upgrades --upgrade
-  - sudo mpm --admin --install=lm,lm-math,unicode-math
+  - sudo mpm --admin --install=lm-math,unicode-math
   - arara --version     # scarica arara da MikTeX e ne visualizza la versione
   - gs --version        # visualizza la versione di Ghostscript
   - dot -V              # visualizza la versione di Graphviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ script:
   - arara --log --verbose tesi.tex
   - chktex tesi.tex
 after_failure:
+  - cat ${TRAVIS_HOME}/.miktex/texmfs/data/miktex/log/lualatex.log
   - cat arara.log
   - cat report.log
 # TODO: per abilitare le release su GitHub, configurare quanto segue

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+version: ~> 1.0
+os: linux
+dist: bionic
+language: shell
+addons:
+  apt:
+    packages:
+      - graphviz      # Graphviz è utilizzato per l'elaborazione dei file DOT e GV
+      - gnuplot       # Gnuplot è utilizzato per l'elaborazione delle figure in TikZ
+      - icc-profiles  # i profili colore sono necessari per la generazione di PDF/A
+      - miktex        # MikTeX è la distribuzione LaTeX scelta
+      - openjdk-8-jre-headless  # arara richiede Java
+      - inkscape      # Inkscape è utilizzato per l'elaborazione di vettoriali SVG
+      - ghostscript   # Ghostscript è utilizzato per l'elaborazione di file EPS
+    sources:
+      - sourceline: "deb http://miktex.org/download/ubuntu bionic universe"
+        key_url: "http://keyserver.ubuntu.com/pks/lookup?op=get&search=miktex"
+      - sourceline: "ppa:inkscape.dev/stable"
+install:
+  - sudo miktexsetup --shared=yes finish
+  - sudo initexmf --admin --set-config-value [MPM]AutoInstall=1
+  - arara --version     # scarica arara da MikTeX e ne visualizza la versione
+  - gs --version        # visualizza la versione di Ghostscript
+  - dot -V              # visualizza la versione di Graphviz
+  - pygmentize -V       # visualizza la versione di Pygments
+  - inkscape --version  # visualizza la versione di Inkscape
+script:
+  - arara --log --verbose tesi.tex
+  - chktex tesi.tex
+after_failure:
+  - cat arara.log
+  - cat report.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - ghostscript     # Ghostscript è utilizzato per l'elaborazione di file EPS
       - python-pygments # Pygments è utilizzato per la colorazione della sintassi del codice con minted
     sources:
-      - sourceline: "deb http://miktex.org/download/ubuntu bionic universe"
+      - sourceline: "deb [arch=amd64] http://miktex.org/download/ubuntu bionic universe"
         key_url: "http://keyserver.ubuntu.com/pks/lookup?op=get&search=miktex"
       - sourceline: "ppa:inkscape.dev/stable"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,13 @@ script:
 after_failure:
   - cat arara.log
   - cat report.log
+# TODO: per abilitare le release su GitHub, configurare quanto segue
+# deploy:
+#   provider: releases
+#   token:
+#     secure:
+#   file: "tesi.pdf"
+#   cleanup: true
+#   draft: true
+#   on:
+#     repo:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
 install:
   - sudo miktexsetup --shared=yes finish
   - sudo initexmf --admin --set-config-value [MPM]AutoInstall=1
-  - sudo mpm --package-level=basic --find-upgrades --upgrade
+  - sudo mpm --admin --package-level=basic --find-upgrades --upgrade
   - arara --version     # scarica arara da MikTeX e ne visualizza la versione
   - gs --version        # visualizza la versione di Ghostscript
   - dot -V              # visualizza la versione di Graphviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
   - sudo miktexsetup --shared=yes finish
   - sudo initexmf --admin --set-config-value [MPM]AutoInstall=1
   - sudo mpm --admin --package-level=basic --find-upgrades --upgrade
+  - sudo mpm --admin --install=lm,lm-math,unicode-math
   - arara --version     # scarica arara da MikTeX e ne visualizza la versione
   - gs --version        # visualizza la versione di Ghostscript
   - dot -V              # visualizza la versione di Graphviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ language: shell
 addons:
   apt:
     packages:
-      - graphviz      # Graphviz è utilizzato per l'elaborazione dei file DOT e GV
-      - gnuplot       # Gnuplot è utilizzato per l'elaborazione delle figure in TikZ
-      - icc-profiles  # i profili colore sono necessari per la generazione di PDF/A
-      - miktex        # MikTeX è la distribuzione LaTeX scelta
+      - graphviz        # Graphviz è utilizzato per l'elaborazione dei file DOT e GV
+      - gnuplot         # Gnuplot è utilizzato per l'elaborazione delle figure in TikZ
+      - icc-profiles    # i profili colore sono necessari per la generazione di PDF/A
+      - miktex          # MikTeX è la distribuzione LaTeX scelta
       - openjdk-8-jre-headless  # arara richiede Java
-      - inkscape      # Inkscape è utilizzato per l'elaborazione di vettoriali SVG
-      - ghostscript   # Ghostscript è utilizzato per l'elaborazione di file EPS
+      - inkscape        # Inkscape è utilizzato per l'elaborazione di vettoriali SVG
+      - ghostscript     # Ghostscript è utilizzato per l'elaborazione di file EPS
+      - python-pygments # Pygments è utilizzato per la colorazione della sintassi del codice con minted
     sources:
       - sourceline: "deb http://miktex.org/download/ubuntu bionic universe"
         key_url: "http://keyserver.ubuntu.com/pks/lookup?op=get&search=miktex"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
 install:
   - sudo miktexsetup --shared=yes finish
   - sudo initexmf --admin --set-config-value [MPM]AutoInstall=1
+  - sudo mpm --package-level=basic --find-upgrades --upgrade
   - arara --version     # scarica arara da MikTeX e ne visualizza la versione
   - gs --version        # visualizza la versione di Ghostscript
   - dot -V              # visualizza la versione di Graphviz

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Unibo Tesi
 
+[![Build Status](https://travis-ci.com/NiccoMlt/Unibo-Tesi.svg?branch=master)](https://travis-ci.com/NiccoMlt/Unibo-Tesi)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 


### PR DESCRIPTION
Add support to _continuous integration_ with Travis CI.

The pipeline will build the document with **MikTeX** on **Ubuntu 18.04**.2 LTS **Bionic** Beaver.