### PR TITLE
fix: remove tocbibind package

### DIFF
--- a/tesi.tex
+++ b/tesi.tex
@@ -149,17 +149,6 @@
   titletoc,                   % Aggiunge la parola Appendice per ogni capitolo dell'appendice nell'indice
   title%                      % Aggiunge la parola Appendice per ogni capitolo dell'appendice
 ]{appendix}                     % modifica la gestione dell'appendice, e aggiunge l'ambiente appendices alternativo al comando \appendix
-\usepackage[%
-  %notbib,                    % rimuove la bibliografia dall'indice
-  notindex,                   % rimuove l'indice dall'indice
-  nottoc,                     % rimuove la Table of Contents dall'indice
-  notlot,                     % rimuove la lista delle tabelle dall'indice
-  notlof,                     % rimuove la lista delle figure dall'indice
-  %chapter,                   % "Use chapter-level headings, if possible"
-  %section,                   % "Use section-level headings, if possible"
-  %numbib                     % numera il capitolo della bibliografia
-  %numindex                   % numera il capitolo dell'indice
-]{tocbibind}                    % aggiunge cose all'indice
 % \usepackage[htt]{hyphenat}    % permette la sillabazione dei blocchi di testo monospaziato
 % \usepackage{enumerate}        % aggiunge un argomento opzionale che determina come comporre l’etichetta numerata delle liste
 


### PR DESCRIPTION
Because tocbibind clashes with KOMA-script classes, the removal of the package should also remove
the warning

fix #2